### PR TITLE
Update requirements for browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Go 1.11
 * npm
+* Chrome 69 or Firefox 62
 
 ## up and running
 


### PR DESCRIPTION
flat() is not supported on older Chrome versions